### PR TITLE
Theocratic Vassals - Radoslaw

### DIFF
--- a/HPM/events/CleanUp.txt
+++ b/HPM/events/CleanUp.txt
@@ -1074,6 +1074,12 @@ country_event = {
 		NOT = { tag = SUD }
 		NOT = { tag = TPG }
 		NOT = { tag = MGL }
+		NOT = {
+			is_vassal = yes
+			overlord = {
+				government = theocracy
+			}
+		}
 	}
 
 	mean_time_to_happen = { months = 1 }


### PR DESCRIPTION
Allows vassals of theocracies to remain theocracies until freed.